### PR TITLE
Fix linking issue and box_keypair

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ linux: libsodium.so sodium.elc
 windows: libsodium.dll sodium.elc
 
 libsodium.so: libsodium.c
-	$(CC) -shared $(CFLAGS) $(LDFLAGS) -o $@ $^
+	$(CC) -shared $(CFLAGS) $^ $(LDFLAGS) -o $@
 
 libsodium.dll: libsodium.c
 	$(MINGW_CC) -shared $(CFLAGS) $(LCDFLAGS) -o $@ $^

--- a/libsodium.c
+++ b/libsodium.c
@@ -117,6 +117,7 @@ box_keypair(emacs_env *env, ptrdiff_t n, emacs_value *args, void *ptr)
   fun_args[0] = pk_pair;
   fun_args[1] = sk_pair;
 
+  list = env->intern(env, "list");
   return env->funcall(env, list, 2, fun_args);
 }
 


### PR DESCRIPTION
Hello,

I was looking to try out keepassxc.el and ran into issues. This pull request contains the fixes that I used to get the sodium.el part working again.

This fixes #2 and an issue I found where sodium-box-keypair was returning nil (instead of a list)